### PR TITLE
Fixes IE support for elm/files

### DIFF
--- a/src/Elm/Kernel/Json.js
+++ b/src/Elm/Kernel/Json.js
@@ -328,7 +328,7 @@ function _Json_runArrayDecoder(decoder, value, toElmValue)
 
 function _Json_isArray(value)
 {
-	return Array.isArray(value) || (typeof FileList === 'function' && value instanceof FileList);
+	return Array.isArray(value) || (typeof FileList !== 'undefined' && value instanceof FileList);
 }
 
 function _Json_toElmArray(array)


### PR DESCRIPTION
The defensive check for node.js support causes IE to break. This MR updates File constructor test.

IE doesn't support the File constructor, but it does support the File API. In IE, `typeof FileList` evaluates to `"object"`.

This broke our app when we upgraded to latest versions.

fixes: https://github.com/elm/json/issues/11