### PR TITLE
explain that map2 takes a constructor function as first argument

### DIFF
--- a/src/Json/Decode.elm
+++ b/src/Json/Decode.elm
@@ -393,6 +393,31 @@ objects with many fields:
 
 It tries each individual decoder and puts the result together with the `Point`
 constructor.
+
+In this example, we use the `Point` type alias because a type alias
+generates a record constructor function for the type. `map2` takes as its
+first argument a function that constructs the type in question.
+
+Thus if you're working with an opaque type, which unlike a type alias does
+not expose a constructor function, you will have to write your own function
+that constructs the type, like so:
+
+type Point =
+  PointConstructor { x: Float, y: Float }
+
+initPoint : Point
+initPoint =
+  PointConstructor {
+    x : 0
+    y : 0
+  }
+
+point : Decoder Point
+point =
+  map2 initPoint
+    (field "x" float")
+    (field "y" float")
+
 -}
 map2 : (a -> b -> value) -> Decoder a -> Decoder b -> Decoder value
 map2 =


### PR DESCRIPTION
This PR explains more explicitly how `map2` takes a type constructor function as its first argument.

### Why?
If you don't know that a type alias generates a record constructor for you, then it's hard to see what's happening when we use `Point` in this example. When this is paired with misleading info about what `map2` takes as arguments in the elm guide, it's hard to reason about what `map2` takes as arguments. I've attempted to clarify this in the elm guide with this PR - https://github.com/evancz/guide.elm-lang.org/pull/24. I think that adding more explanation here will be helpful as well, particularly for beginners who might not be firm in their understanding  of how a a type alias generates a record constructor.