### PR TITLE
Make HTMLCollection and NodeList valid array types

### DIFF
--- a/src/Elm/Kernel/Json.js
+++ b/src/Elm/Kernel/Json.js
@@ -328,7 +328,10 @@ function _Json_runArrayDecoder(decoder, value, toElmValue)
 
 function _Json_isArray(value)
 {
-	return Array.isArray(value) || (typeof FileList !== 'undefined' && value instanceof FileList);
+	return Array.isArray(value)
+		|| (typeof FileList !== 'undefined' && value instanceof FileList)
+		|| (typeof HTMLCollection !== 'undefined' && value instanceof HTMLCollection)
+		|| (typeof NodeList !== 'undefined' && value instanceof NodeList);
 }
 
 function _Json_toElmArray(array)


### PR DESCRIPTION
SSCCE: https://ellie-app.com/8zCdXgf99qCa1

On the SSCCE above I would expect the decoders for both childNodes ([NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList)) and children ([HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection)) to decode correctly to a list - this is similar to how it currently handles [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList).

Found this issue when trying to implement a flexible data table, similar to the one shown here: https://adamlynch.com/flexible-data-tables-with-css-grid/#resizing-columns-with-grid