### PR TITLE
Correct equality check on oneOf decoders for virtual DOM diffing.

### DIFF
--- a/src/Elm/Kernel/Json.js
+++ b/src/Elm/Kernel/Json.js
@@ -380,7 +380,7 @@ function _Json_equality(x, y)
 			return x.__index === y.__index && _Json_equality(x.__decoder, y.__decoder);
 
 		case __1_MAP:
-			return x.__func === y.__func && _Json_listEquality(x.__decoders, y.__decoders);
+			return x.__func === y.__func && _Json_arrayEquality(x.__decoders, y.__decoders);
 
 		case __1_AND_THEN:
 			return x.__callback === y.__callback && _Json_equality(x.__decoder, y.__decoder);
@@ -390,7 +390,7 @@ function _Json_equality(x, y)
 	}
 }
 
-function _Json_listEquality(aDecoders, bDecoders)
+function _Json_arrayEquality(aDecoders, bDecoders)
 {
 	var len = aDecoders.length;
 	if (len !== bDecoders.length)
@@ -407,6 +407,29 @@ function _Json_listEquality(aDecoders, bDecoders)
 	return true;
 }
 
+function _Json_listEquality(aDecoders, bDecoders)
+{
+	var tempA = aDecoders;
+	var tempB = bDecoders;
+	while (tempA.b)
+	{
+		if (!tempB.b)
+		{
+			return false;
+		}
+		if (!_Json_equality(tempA.a, tempB.a))
+		{
+			return false;
+		}
+		tempA = tempA.b;
+		tempB = tempB.b;
+	}
+	if (tempB.b)
+	{
+		return false;
+	}
+	return true;
+}
 
 // ENCODE
 


### PR DESCRIPTION
This fixes the equality check on oneOf decoders, and this solution will work with 0.19.1 in --optimize mode, or without --optimize.

The problem can be seen in this Ellie, the `oneOf` decoder there captures stale state from the model, as the vdom diffing fails to detect that it has changed:

https://ellie-app.com/3HKzFLVbBhxa1

Fixes these issues:

https://github.com/elm/json/issues/15
https://github.com/elm/core/issues/904

This PR was adapted from the original PR (now closed):

https://github.com/elm/core/pull/905